### PR TITLE
Provide a default localhost IP instead of hostname

### DIFF
--- a/ledfx/http.py
+++ b/ledfx/http.py
@@ -23,7 +23,7 @@ class HttpServer(object):
         self.register_routes()
 
         if host is None:
-            host = socket.gethostbyname(socket.gethostname())
+            host = '127.0.0.1'
         if port is None:
             port = 8888
 


### PR DESCRIPTION
I don't keep the hostname of my machine in `/etc/hosts` nor in DNS fed by DHCP leases, so when a lookup occurs for `$hostname`, it crashes:

```
Traceback (most recent call last):
  File "~/.local/bin/ledfx", line 8, in <module>
    sys.exit(main())
  File "~/.local/lib/python3.7/site-packages/ledfx/__main__.py", line 88, in main
    ledfx = LedFxCore(config_dir = args.config)
  File "~/.local/lib/python3.7/site-packages/ledfx/core.py", line 42, in __init__
    port=port)
  File "~/.local/lib/python3.7/site-packages/ledfx/http.py", line 26, in __init__
    host = socket.gethostbyname(socket.gethostname())
socket.gaierror: [Errno -2] Name or service not known
```

This change will resolve an inconsistency in behavior. While the vast majority of cases resolve `$hostname` to `127.0.0.1`, this may also resolve to the DHCP address, or not at all, instead if `/etc/hosts` and the local resolver are set up just right.

Since in the vast majority of cases `$hostname` resolves to `127.0.0.1` (or `::1`), this seems like the intended behavior.
If the intended behavior is to be available externally by default, a host of `0.0.0.0` (or `::`) would be more appropriate.

Thank you