### PR TITLE
Revert "auto-detect ip" and add default host

### DIFF
--- a/ledfx/config.py
+++ b/ledfx/config.py
@@ -10,7 +10,7 @@ CONFIG_DIRECTORY = '.ledfx'
 CONFIG_FILE_NAME = 'config.yaml'
 
 CORE_CONFIG_SCHEMA = vol.Schema({
-    vol.Optional('host'): str,
+    vol.Optional('host', default = '127.0.0.1'): str,
     vol.Optional('port', default = 8888): int,
     vol.Optional('dev_mode', default = False): bool,
     vol.Optional('max_workers', default = 10): int,

--- a/ledfx/core.py
+++ b/ledfx/core.py
@@ -34,9 +34,7 @@ class LedFxCore(object):
 
         self.events = Events(self)
         self.http = HttpServer(
-            ledfx=self,
-            host=self.config.get('host', None),
-            port=self.config.get('port', None))
+            ledfx=self, host=self.config['host'], port=self.config['port'])
         self.exit_code = None
 
     def dev_enabled(self):

--- a/ledfx/http.py
+++ b/ledfx/http.py
@@ -1,6 +1,5 @@
 import logging
 import jinja2
-import socket
 import aiohttp_jinja2
 from aiohttp import web
 import aiohttp
@@ -21,11 +20,6 @@ class HttpServer(object):
             self.app,
             loader=jinja2.PackageLoader('ledfx_frontend', '.'))
         self.register_routes()
-
-        if host is None:
-            host = socket.gethostbyname(socket.gethostname())
-        if port is None:
-            port = 8888
 
         self._ledfx = ledfx
         self.host = host


### PR DESCRIPTION
This reverts commit d7f07be888f5f97d237e11bdbaecf6d4fff5eb3e and adds a default for host.

When a lookup occurs for `$hostname` on my machine, ledfx crashes.
I do not keep the hostname of my machine in `/etc/hosts` nor in DNS fed by DHCP leases.

```
Traceback (most recent call last):
  File "~/.local/bin/ledfx", line 8, in <module>
    sys.exit(main())
  File "~/.local/lib/python3.7/site-packages/ledfx/__main__.py", line 88, in main
    ledfx = LedFxCore(config_dir = args.config)
  File "~/.local/lib/python3.7/site-packages/ledfx/core.py", line 42, in __init__
    port=port)
  File "~/.local/lib/python3.7/site-packages/ledfx/http.py", line 26, in __init__
    host = socket.gethostbyname(socket.gethostname())
socket.gaierror: [Errno -2] Name or service not known
```

This change will resolve an inconsistency in behavior.

While the vast majority of cases resolve `$hostname` to `127.0.0.1`, this may resolve to the DHCP address or not at all, instead, if `/etc/hosts` and the local resolver are set up just right.

Defaulting to `127.0.0.1` seems like the intended behavior, coincident with how binding to `$hostname` normally works, and is consistent with the previous behavior, too.
If the intended behavior is to be available on an IP of the machine by default, a default of `0.0.0.0` would be more appropriate.