### PR TITLE
Add missing command for windows

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -35,6 +35,7 @@ To get started on Windows it is highly recommended that you use `Anaconda <https
 
     conda config --add channels conda-forge
     conda install aubio portaudio pywin32
+    conda install -c anaconda pyaudio
     pip install ledfx
 
 **3.** Launch LedFx with the ``--open-ui`` option to launch the browser:


### PR DESCRIPTION
Was struggling to get LEDfx to launch on windows 10 so after scouring the web I came across:

https://stackoverflow.com/questions/50243645/i-cant-import-pyaudio

Which had the same error outlined in #98 

After performing the additional installation of `pyaudio` LEDfx was able to launch.

Note that `conda install pyaudio` was not enough we needed the `-c anaconda` added to the command.