### PR TITLE
Add additional install for working PyAudio/portaudio

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -36,6 +36,7 @@ To get started on Windows it is highly recommended that you use `Anaconda <https
     conda config --add channels conda-forge
     conda install aubio portaudio pywin32
     conda install -c anaconda pyaudio
+    conda install -c anaconda portaudio
     pip install ledfx
 
 **3.** Launch LedFx with the ``--open-ui`` option to launch the browser:


### PR DESCRIPTION
Add additional install for working PyAudio/portaudio. Similar to https://github.com/ahodges9/LedFx/pull/99

Fix `Could not import the PyAudio C module '_portaudio'` error when running `ledfx --open-ui`

I see that `portaudio` was installed in the command above but wasn't able to get ledfx running until using this fix from 

 - https://github.com/ahodges9/LedFx/issues/98#issuecomment-618827303
 - https://stackoverflow.com/questions/50243645/i-cant-import-pyaudio