### PR TITLE
Fix python setup.py install 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,7 @@ package-lock.json
 .pydevproject
 .settings
 .idea
-#.vscode
+.vscode/settings.json
 *.code-workspace
 
 # Package files

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
     python_requires=const.REQUIRED_PYTHON_STRING,
     include_package_data=True,
     # packages=find_packages(),
-    zip_safe=True,
+    zip_safe=False,
     entry_points={"console_scripts": ["ledfx = ledfx.__main__:main"]},
     package_data={"ledfx_frontend": ["*"], "": ["*.npy"], "": ["*.yaml"]},
 )


### PR DESCRIPTION
When installing via `python setup.py install` ledfx would error out 

```
❯ ledfx
/Users/thatdonfc/anaconda3/envs/ledfx-py39/lib/python3.9/site-packages/aiohttp/helpers.py:107: DeprecationWarning: "@coroutine"
decorator is deprecated since Python 3.8, use "async def" instead
  def noop(*args, **kwargs):  # type: ignore
Loading configuration file from /Users/thatdonfc/.ledfx
Loading default presets from /Users/thatdonfc/anaconda3/envs/ledfx-py39/lib/python3.9/site-packages/ledfx_dev-0.9.0-py3.9.egg/ledfx
Failed to load default_presets.yaml
Traceback (most recent call last):
  File "/Users/thatdonfc/anaconda3/envs/ledfx-py39/bin/ledfx", line 33, in <module>
    sys.exit(load_entry_point('ledfx-dev==0.9.0', 'console_scripts', 'ledfx')())
  File "/Users/thatdonfc/anaconda3/envs/ledfx-py39/lib/python3.9/site-packages/ledfx_dev-0.9.0-py3.9.egg/ledfx/__main__.py", line 178, in main
  File "/Users/thatdonfc/anaconda3/envs/ledfx-py39/lib/python3.9/site-packages/ledfx_dev-0.9.0-py3.9.egg/ledfx/core.py", line 23, in __init__
  File "/Users/thatdonfc/anaconda3/envs/ledfx-py39/lib/python3.9/site-packages/ledfx_dev-0.9.0-py3.9.egg/ledfx/config.py", line 118, in load_default_presets
NotADirectoryError: [Errno 20] Not a directory: '/Users/thatdonfc/anaconda3/envs/ledfx-py39/lib/python3.9/site-packages/ledfx_dev-0.9.0-py3.9.egg/ledfx/default_presets.yaml' 
```

Setting `zip_safe=False` in setup.py fixes this error.