### PR TITLE
Add critical warning about old repo

### DIFF
--- a/ledfx/__main__.py
+++ b/ledfx/__main__.py
@@ -177,9 +177,8 @@ def main():
         update_ledfx()
     config_helpers.ensure_config_directory(args.config)
     ledfx = LedFxCore(config_dir=args.config, host=args.host, port=args.port)
-
+    _LOGGER.critical("THIS GIT REPO IS NO LONGER MAINTAINED. PLEASE UPDATE YOUR SOURCES TO THE OFFICIAL LEDFX GITHUB - GIT.LEDFX.APP")
     ledfx.start(open_ui=args.open_ui)
-
-
+    
 if __name__ == "__main__":
     sys.exit(main())


### PR DESCRIPTION
This PR just adds a warning.
If we want to move all the files, we can do that - but it will likely break a lot of peoples forks in the meantime.
For now, I've added a critical warning on launch.
Thanks for all your work Austin, we hope to see you soon.